### PR TITLE
add options to `binary_log_test` use a binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,5 +33,6 @@ build --@rules_clang_tidy//:config=//:tidy-config
 
 test --test_output=errors
 test --test_summary=detailed
+test --test_verbose_timeout_warnings
 
 try-import %workspace%/user.bazelrc

--- a/example/semihosting/BUILD.bazel
+++ b/example/semihosting/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//rules:binary_log.bzl", "binary_log", "binary_log_test")
+load("//rules:binary_log.bzl", "binary_log_test")
 load("//rules:transitions.bzl", "transition_config_binary")
 
 cc_binary(
@@ -24,14 +24,10 @@ transition_config_binary(
     semihosting = "enabled",
 )
 
-binary_log(
-    name = "semihosting.lm3s6965evb.log",
-    src = "semihosting.lm3s6965evb",
-    run_under = "//:qemu_runner",
-)
-
 binary_log_test(
     name = "semihosting.lm3s6965evb.test",
+    size = "small",
+    src = "semihosting.lm3s6965evb",
     expected_stdout = "stdout",
-    logs = ":semihosting.lm3s6965evb.log",
+    run_under = "//:qemu_runner",
 )


### PR DESCRIPTION
Add `src` and `run_under` attributes to `binary_log_test`, allowing the
rule to create the log files for stdout and stderr directly instead of
requiring the use of a separate `binary_log` rule.

Change-Id: I1138f42e6f074c2feca7685d228b1c46af46f123