### PR TITLE
remove use of `data_runfiles`

### DIFF
--- a/rules/cc_test_runner_toolchain.bzl
+++ b/rules/cc_test_runner_toolchain.bzl
@@ -53,7 +53,6 @@ exec '{test_runner}' '{binary}' "$@"
         files
         for files in [
             test_runner[DefaultInfo].default_runfiles,
-            test_runner[DefaultInfo].data_runfiles,
         ]
         if files
     ])

--- a/rules/transitions.bzl
+++ b/rules/transitions.bzl
@@ -40,8 +40,6 @@ def _transition_config_binary_impl(ctx):
 
     binary = default_info.files_to_run.executable
     runfiles = default_info.default_runfiles
-    if default_info.data_runfiles:
-        runfiles = runfiles.merge(default_info.data_runfiles)
 
     out = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.symlink(


### PR DESCRIPTION
Only use `DefaultInfo.default_runfiles` and not
`DefaultInfo.data_runfiles`.

https: //bazel.build/extending/rules#runfiles_features_to_avoid
Change-Id: I52ece3ba640c687a1fd54fce20d12d0aff01372f