### PR TITLE
define a `gdb_qemu_runner`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//rules:cc_test_runner_toolchain.bzl", "cc_test_runner_toolchain")
+load("//rules:gdb_qemu_runner.bzl", "gdb_qemu_runner")
 load("//rules:qemu_runner.bzl", "qemu_runner")
 
 xcode_config(name = "host_xcodes")
@@ -20,14 +21,14 @@ qemu_runner(
     visibility = ["//visibility:public"],
 )
 
-qemu_runner(
-    name = "qemu_semihosting_runner",
-    extra_args = ["-semihosting"],
+gdb_qemu_runner(
+    name = "gdb_qemu_runner",
+    visibility = ["//visibility:public"],
 )
 
 cc_test_runner_toolchain(
     name = "qemu_cc_test_runner_toolchain",
-    test_runner = ":qemu_semihosting_runner",
+    test_runner = "//rules:qemu_semihosting_runner",
 )
 
 toolchain(

--- a/example/semihosting/README.md
+++ b/example/semihosting/README.md
@@ -24,3 +24,12 @@ bazel run \
   --run_under=@cortex_m//:qemu_runner \
   //semihosting:semihosting.lm3s6965evb
 ```
+
+or
+
+```sh
+bazel run \
+  --run_under=@cortex_m//:gdb_qemu_runner \
+  -c dbg \
+  //semihosting:semihosting.lm3s6965evb
+```

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,0 +1,17 @@
+load(":qemu_runner.bzl", "qemu_runner")
+
+qemu_runner(
+    name = "qemu_semihosting_runner",
+    extra_args = ["-semihosting"],
+    visibility = ["//:__subpackages__"],
+)
+
+qemu_runner(
+    name = "qemu_gdb_runner",
+    extra_args = [
+        "-semihosting",
+        "-s",
+        "-S",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rules/gdb_qemu_runner.bzl
+++ b/rules/gdb_qemu_runner.bzl
@@ -1,0 +1,136 @@
+"""Rules for running binaries in QEMU with GDB attached."""
+
+load("//rules/private:runner.bzl", "load_config", "rlpath", "runfiles_init")
+
+def _impl(ctx):
+    cfg = load_config(ctx.attr)
+
+    out = ctx.actions.declare_file(ctx.label.name)
+
+    gdb_args = (
+        [
+            "-ex",
+            "'target remote :1234'",
+        ] if ctx.attr.enable_default_args else []
+    )
+    gdb_args.extend(ctx.attr.extra_args)
+
+    ctx.actions.write(
+        output = out,
+        content = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (($# == 0)); then
+    echo "usage: bazel run {label} <binary> [additional-gdb-args...]"
+    echo ""
+    echo "Run a binary with QEMU {for_machine} and connect to it with GDB"
+    echo ""
+    echo "Arguments:"
+    echo "  <binary>                  Path to the binary/ELF file to run"
+    echo "  [additional-gdb-args...] Additional arguments to pass to GDB"
+    echo ""
+    echo "Examples:"
+    echo "  bazel run {label} <binary>"
+    echo "  bazel run {label} <binary> -ex 'break main'"
+    exit 1
+fi
+
+{runfiles_init}
+
+binary="$1"
+args=({gdb_args})
+args+=("${{@:2}}")
+
+printf "INFO: Starting QEMU runner process..." >&2
+$(rlocation {qemu_runner}) "$binary" &
+QEMU_PID=$!
+echo "pid $QEMU_PID" >&2
+
+{{
+  while true; do
+    if ! ps_stat=$(ps -p $QEMU_PID -o stat=); then
+      # QEMU process does not exist
+      kill -TERM $$ &> /dev/null
+      break
+    elif [[ $ps_stat == *Z* ]]; then
+      # QEMU process is a zombie
+      kill -TERM $$
+      break
+    else
+      sleep 0.1
+    fi
+  done
+}} &
+
+echo "INFO: Starting GDB..." >&2
+exec $(rlocation {arm_none_eabi_gdb}) "${{args[@]}}" "$binary"
+""".format(
+            gdb_args = " ".join(gdb_args),
+            label = str(ctx.label).replace("@@", "@").replace("@//", "//"),
+            for_machine = ("for " + cfg.machine) if cfg.machine else "",
+            runfiles_init = runfiles_init,
+            qemu_runner = rlpath(ctx.attr.qemu_runner),
+            arm_none_eabi_gdb = rlpath(ctx.attr._arm_none_eabi_gdb),
+        ),
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = out,
+            runfiles = ctx.runfiles(
+                transitive_files = depset(transitive = [
+                    ctx.attr.qemu_runner.files,
+                    ctx.attr._arm_none_eabi_gdb.files,
+                    ctx.attr._runfiles.files,
+                ]),
+            ).merge_all([
+                ctx.attr.qemu_runner[DefaultInfo].default_runfiles,
+                ctx.attr._arm_none_eabi_gdb[DefaultInfo].default_runfiles,
+            ]),
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+            inherited_environment = [],
+        ),
+    ]
+
+gdb_qemu_runner = rule(
+    implementation = _impl,
+    attrs = {
+        "extra_args": attr.string_list(
+            default = [],
+            doc = "Extra arguments to pass to GDB",
+        ),
+        "enable_default_args": attr.bool(
+            default = True,
+            doc = "Enable default arguments passed to GDB",
+        ),
+        "env": attr.string_dict(
+            doc = "Environment variables set when running GDB and QEMU",
+        ),
+        "qemu_runner": attr.label(
+            default = "//rules:qemu_gdb_runner",
+            executable = True,
+            cfg = "exec",
+        ),
+        "_arm_none_eabi_gdb": attr.label(
+            default = "@arm_none_eabi//:gdb",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+        "_machine": attr.label(
+            default = "//config:machine",
+        ),
+        "_runfiles": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+    },
+    executable = True,
+    provides = [DefaultInfo, RunEnvironmentInfo],
+    doc = (
+        "Runner that starts QEMU in the background and connects GDB to it."
+    ),
+)

--- a/rules/private/runner.bzl
+++ b/rules/private/runner.bzl
@@ -1,0 +1,61 @@
+"""
+Utility functions for runner rules.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+visibility("//...")
+
+runfiles_init = """
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+"""
+
+def load_config(attrs):
+    """
+    Load configuration from attributes.
+
+    Args:
+      attrs:
+        `attr` field of the rule `ctx` paramter
+
+    Returns:
+      A struct which contains a entry per configuration option present in
+      `attrs`.
+    """
+    cfg = {}
+
+    if hasattr(attrs, "_semihosting"):
+        cfg["semihosting"] = attrs._semihosting[BuildSettingInfo]
+
+    if hasattr(attrs, "_machine"):
+        cfg["machine"] = attrs._machine[BuildSettingInfo].value
+
+    return struct(**cfg)
+
+def rlpath(target):
+    """
+    Returns the rlocation input path of a target.
+
+    This path can be used as the first argument to `rlocation`.
+    """
+    label = target.label
+
+    return "/".join([
+        part
+        for part in [
+            label.workspace_name or "_main",
+            label.package,
+            label.name,
+        ]
+        if part
+    ])

--- a/rules/qemu_runner.bzl
+++ b/rules/qemu_runner.bzl
@@ -2,30 +2,10 @@
 run QEMU for a specific machine
 """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-
-_runfiles_init = """
-# --- begin runfiles.bash initialization v3 ---
-# Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-# shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-source "$0.runfiles/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v3 ---
-"""
-
-def _config_from(attrs):
-    return struct(
-        semihosting = attrs._semihosting[BuildSettingInfo],
-        machine = attrs._machine[BuildSettingInfo].value,
-    )
+load("//rules/private:runner.bzl", "load_config", "rlpath", "runfiles_init")
 
 def _impl(ctx):
-    cfg = _config_from(ctx.attr)
+    cfg = load_config(ctx.attr)
 
     out = ctx.actions.declare_file(ctx.label.name)
 
@@ -48,7 +28,7 @@ set -euo pipefail
 if (($# == 0)); then
     echo "usage: bazel run {label} <binary> [additional-qemu-args...]"
     echo ""
-    echo "Run binary with QEMU {for_machine}"
+    echo "Run a binary with QEMU {for_machine}"
     echo ""
     echo "Arguments:"
     echo "  <binary>                  Path to the binary/ELF file to run"
@@ -73,7 +53,7 @@ args+=("${{@:2}}")
 exit_code=0
 $(rlocation {qemu_system_arm}) "${{args[@]}}" || exit_code=$?
 if ((exit_code != {exit_code})); then
-    printf "QEMU exited with \'$exit_code\' but " >&2
+    printf "ERROR: QEMU exited with \'$exit_code\' but " >&2
     printf "this runner expected '{exit_code}'\n" >&2
     exit 1
 fi
@@ -81,8 +61,8 @@ fi
             fixed_args = " ".join(fixed_args),
             label = str(ctx.label).replace("@@", "@").replace("@//", "//"),
             for_machine = ("for " + cfg.machine) if cfg.machine else "",
-            runfiles_init = _runfiles_init,
-            qemu_system_arm = "qemu-system-arm/qemu-system-arm",
+            runfiles_init = runfiles_init,
+            qemu_system_arm = rlpath(ctx.attr._qemu_system_arm),
             exit_code = ctx.attr.exit_code,
         ),
         is_executable = True,


### PR DESCRIPTION
Provide a new runner that runs a binary with QEMU as a background
process and then connects to it with GDB.

This simplifies the debug process as the user can use a single `bazel
run` command instead of two.

From the example directory:

  bazel run \
    --run_under=@cortex_m//:gdb_qemu_runner \
    -c dbg \
    //semihosting:semihosting.lm3s6965evb

or from the root directory:

  bazel run \
    --run_under=//:gdb_qemu_runner \
    -c dbg \
    //test:hello_semihosting_test.transition

By default the `//:gdb_qemu_runner` will launch QEMU with semihosting
enabled, start a GDB server on port 1234, and freeze the CPU at startup.
GDB is then started and will connect to QEMU.

Change-Id: I05fa57a243ca6f46b5186cae58c3a80031029536