### PR TITLE
use `gdb` from Nix

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,18 @@ filegroup(
     visibility = [":__subpackages__"],
 )
 
+alias(
+    name = "gdb",
+    actual = "@gdb",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "qemu-system-arm",
+    actual = "@qemu-system-arm",
+    visibility = ["//visibility:public"],
+)
+
 qemu_runner(
     name = "qemu_runner",
     visibility = ["//visibility:public"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,6 +56,7 @@ flake_package_deps = use_extension(
 )
 use_repo(
     flake_package_deps,
+    "gdb",
     "qemu-system-arm",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -282,7 +282,7 @@
   "moduleExtensions": {
     "//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "YpD/p2YS9qYE8w6PMmYRnrWJ8+0A1ET4O5w0xuCGZdw=",
+        "bzlTransitiveDigest": "qpotQnfiL254H10XNdJjWy5E2TXC9q2agaNph+eRMbY=",
         "usagesDigest": "mK4YgaAu5b/qaOsvCSv9KZ6YWfBZ1+idETueZeq0Zgw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -303,6 +303,20 @@
               "nix_flake_file_deps": {},
               "package": "qemu",
               "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"qemu-system-arm\",\n    out = \"qemu-system-arm\",\n    src = \"bin/qemu-system-arm\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
+            }
+          },
+          "gdb": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "gdb",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"gdb\",\n    out = \"gdb\",\n    src = \"bin/gdb\",\n    visibility = [\"//visibility:public\"],\n)\n",
               "nixopts": [],
               "quiet": false,
               "fail_not_supported": true,

--- a/example/MODULE.bazel.lock
+++ b/example/MODULE.bazel.lock
@@ -143,7 +143,7 @@
   "moduleExtensions": {
     "@@cortex_m+//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "YpD/p2YS9qYE8w6PMmYRnrWJ8+0A1ET4O5w0xuCGZdw=",
+        "bzlTransitiveDigest": "WgDjh8zvCyYxxfQ6u6N3hPugYbCYxjTVcKZGNLIHmjI=",
         "usagesDigest": "NBO1GlPzY5bjWCo0LO0EzR3BAY004m157ZYu/eeNkNk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -164,6 +164,20 @@
               "nix_flake_file_deps": {},
               "package": "qemu",
               "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"qemu-system-arm\",\n    out = \"qemu-system-arm\",\n    src = \"bin/qemu-system-arm\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
+            }
+          },
+          "gdb": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@cortex_m++flake_package_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@cortex_m++flake_package_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "gdb",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"gdb\",\n    out = \"gdb\",\n    src = \"bin/gdb\",\n    visibility = [\"//visibility:public\"],\n)\n",
               "nixopts": [],
               "quiet": false,
               "fail_not_supported": true,

--- a/example/minimal/README.md
+++ b/example/minimal/README.md
@@ -3,7 +3,7 @@ Build the target, then pass it to gdb:
 ```sh
 bazel run \
   --platforms=@cortex_m//platform:lm3s6965evb \
-  --run_under=@@toolchains_arm_gnu++arm_toolchain+arm_none_eabi_darwin_arm64//:bin/arm-none-eabi-gdb \
+  --run_under=@cortex_m//:gdb \
   -c dbg \
   //minimal
 ```

--- a/extensions/flake_package_deps.bzl
+++ b/extensions/flake_package_deps.bzl
@@ -34,6 +34,18 @@ _flake_copy = repository_rule(
     ),
 )
 
+def _native_binary_build_file_content(binary):
+    return """
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "{binary}",
+    out = "{binary}",
+    src = "bin/{binary}",
+    visibility = ["//visibility:public"],
+)
+""".format(binary = binary)
+
 def _flake_package_deps_impl(_mctx):
     _flake_copy(
         name = "flake_copy",
@@ -46,16 +58,15 @@ def _flake_package_deps_impl(_mctx):
         nix_flake_file = "@flake_copy//:flake.nix",
         nix_flake_lock_file = "@flake_copy//:flake.lock",
         package = "qemu",
-        build_file_content = """
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+        build_file_content = _native_binary_build_file_content("qemu-system-arm"),
+    )
 
-native_binary(
-    name = "qemu-system-arm",
-    out = "qemu-system-arm",
-    src = "bin/qemu-system-arm",
-    visibility = ["//visibility:public"],
-)
-""",
+    nixpkgs_flake_package(
+        name = "gdb",
+        nix_flake_file = "@flake_copy//:flake.nix",
+        nix_flake_lock_file = "@flake_copy//:flake.lock",
+        package = "gdb",
+        build_file_content = _native_binary_build_file_content("gdb"),
     )
 
 flake_package_deps = module_extension(

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
       in {
-        inherit (pkgs) qemu;
+        inherit (pkgs) gdb qemu;
       }
     );
   };

--- a/rules/gdb_qemu_runner.bzl
+++ b/rules/gdb_qemu_runner.bzl
@@ -64,7 +64,7 @@ qemu_pid=$!
 }} &
 
 echo "INFO: starting GDB..." >&2
-$(rlocation {arm_none_eabi_gdb}) "${{args[@]}}" "$binary"
+$(rlocation {gdb}) "${{args[@]}}" "$binary"
 
 pkill -P $qemu_pid
 
@@ -75,7 +75,7 @@ exit $(cat "$return")
             for_machine = ("for " + cfg.machine) if cfg.machine else "",
             runfiles_init = runfiles_init,
             qemu_runner = rlpath(ctx.attr.qemu_runner),
-            arm_none_eabi_gdb = rlpath(ctx.attr._arm_none_eabi_gdb),
+            gdb = rlpath(ctx.attr._gdb),
         ),
         is_executable = True,
     )
@@ -86,12 +86,12 @@ exit $(cat "$return")
             runfiles = ctx.runfiles(
                 transitive_files = depset(transitive = [
                     ctx.attr.qemu_runner.files,
-                    ctx.attr._arm_none_eabi_gdb.files,
+                    ctx.attr._gdb.files,
                     ctx.attr._runfiles.files,
                 ]),
             ).merge_all([
                 ctx.attr.qemu_runner[DefaultInfo].default_runfiles,
-                ctx.attr._arm_none_eabi_gdb[DefaultInfo].default_runfiles,
+                ctx.attr._gdb[DefaultInfo].default_runfiles,
             ]),
         ),
         RunEnvironmentInfo(
@@ -119,8 +119,8 @@ gdb_qemu_runner = rule(
             executable = True,
             cfg = "exec",
         ),
-        "_arm_none_eabi_gdb": attr.label(
-            default = "@arm_none_eabi//:gdb",
+        "_gdb": attr.label(
+            default = "@gdb",
             allow_single_file = True,
             executable = True,
             cfg = "exec",


### PR DESCRIPTION
Replace use of `arm-none-eabi-gdb` with `gdb` from Nix. `gdb` from Nix
provides multiarch support. On linux-x86_64, `arm-none-eabi-gdb`
requires `libncurses5` and Python 3.8, neither of which are available
with recent Ubuntu releases.

https://github.com/NixOS/nixpkgs/issues/203962
https://stackoverflow.com/questions/53450745/message-unable-to-run-arm-none-eabi-gdb-cannot-find-libncurses-so-5
https://stackoverflow.com/questions/72187185/arm-none-eabi-gdb-cannot-start-because-of-some-python-error
Change-Id: I823d985204244ce1bcbac23ef4e37c70d99eddec