### PR TITLE
update `qemu` semihosting args

### DIFF
--- a/example/MODULE.bazel.lock
+++ b/example/MODULE.bazel.lock
@@ -143,7 +143,7 @@
   "moduleExtensions": {
     "@@cortex_m+//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "WgDjh8zvCyYxxfQ6u6N3hPugYbCYxjTVcKZGNLIHmjI=",
+        "bzlTransitiveDigest": "qpotQnfiL254H10XNdJjWy5E2TXC9q2agaNph+eRMbY=",
         "usagesDigest": "NBO1GlPzY5bjWCo0LO0EzR3BAY004m157ZYu/eeNkNk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,17 +1,31 @@
 load(":qemu_runner.bzl", "qemu_runner")
+load(":transitions.bzl", "transition_config_binary")
 
-qemu_runner(
-    name = "qemu_semihosting_runner",
-    extra_args = ["-semihosting"],
-    visibility = ["//:__subpackages__"],
-)
-
-qemu_runner(
-    name = "qemu_gdb_runner",
-    extra_args = [
-        "-semihosting",
-        "-s",
-        "-S",
-    ],
-    visibility = ["//:__subpackages__"],
-)
+[
+    (
+        qemu_runner(
+            name = "_" + name,
+            extra_args = extra_args,
+            visibility = ["//visibility:private"],
+        ),
+        transition_config_binary(
+            name = name,
+            src = "_" + name,
+            semihosting = "enabled",
+            visibility = ["//:__subpackages__"],
+        ),
+    )
+    for name, extra_args in [
+        (
+            "qemu_semihosting_runner",
+            None,
+        ),
+        (
+            "qemu_gdb_runner",
+            [
+                "-S",
+                "-s",
+            ],
+        ),
+    ]
+]

--- a/rules/qemu_runner.bzl
+++ b/rules/qemu_runner.bzl
@@ -14,7 +14,7 @@ def _impl(ctx):
         "-monitor stdio",
     ] if ctx.attr.enable_default_args else []
     if cfg.semihosting:
-        fixed_args.append("-semihosting")
+        fixed_args.append("-semihosting-config enable=on,target=auto")
     if cfg.machine:
         fixed_args.append("-machine " + cfg.machine)
     fixed_args.extend(ctx.attr.extra_args)
@@ -37,7 +37,7 @@ if (($# == 0)); then
     echo "Examples:"
     echo "  bazel run {label} <binary>"
     echo "  bazel run {label} <binary> -S"
-    echo "  bazel run {label} <binary> -semihosting"
+    echo "  bazel run {label} <binary> -semihosting-config enable=on,target=auto"
     exit 1
 fi
 

--- a/rules/transitions.bzl
+++ b/rules/transitions.bzl
@@ -84,7 +84,6 @@ def _common_attrs(*, default = {}):
     return {
         "src": attr.label(
             mandatory = True,
-            providers = [CcInfo],
             default = default.get("src", None),
             doc = "The binary to transition",
         ),
@@ -114,7 +113,7 @@ transition_config_binary = rule(
     cfg = _config_transition,
     attrs = _common_attrs(),
     executable = True,
-    provides = [DefaultInfo, RunEnvironmentInfo, CcInfo],
+    provides = [DefaultInfo, RunEnvironmentInfo],
 )
 
 transition_config_test = rule(
@@ -127,5 +126,5 @@ transition_config_test = rule(
         },
     ),
     test = True,
-    provides = [DefaultInfo, RunEnvironmentInfo, CcInfo],
+    provides = [DefaultInfo, RunEnvironmentInfo],
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -20,7 +20,6 @@ load("//rules:qemu_runner.bzl", "qemu_runner")
         qemu_runner(
             name = "qemu_failure_runner_{}".format(exit_code),
             exit_code = exit_code,
-            extra_args = ["-semihosting"],
         ),
         qemu_output_test(
             name = "failure_{}_test".format(exit_code),


### PR DESCRIPTION
Set semihosting target to auto so that semihosting calls are routed to
GDB when connected. Remove duplicated semihosting options by performing
a transition that sets `//config:semihosting`.

Change-Id: Ibd78e9b86ff9485725f2230529dd8a12f1e7f0d1