### PR TITLE
update `@toolchain_arm_gnu` for additional toolchain config opts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,16 +20,16 @@ bazel_dep(
     version = "0.13.0",
 )
 
-TOOLCHAINS_ARM_GNU_COMMIT = "5012bfb601600cfbae5322cbc2acfbed41c52e0f"
+TOOLCHAINS_ARM_GNU_COMMIT = "1abff3e6a5f894d0545654800ee0db6ea24a76a3"
 
 archive_override(
     module_name = "toolchains_arm_gnu",
-    integrity = "sha256-wOFizsEMZk1SX+m+39HXoU5yY+3R0VYyqH2g6FTRzdo=",
-    strip_prefix = "bazel-arm-none-eabi-{commit}".format(
+    integrity = "sha256-surv16TjyDtSebSX8fdj85TVnC8wGjIthEk3uHlKvFs=",
+    strip_prefix = "toolchains_arm_gnu-{commit}".format(
         commit = TOOLCHAINS_ARM_GNU_COMMIT,
     ),
     urls = [
-        "https://github.com/oliverlee/bazel-arm-none-eabi/archive/{commit}.tar.gz".format(
+        "https://github.com/hexdae/toolchains_arm_gnu/archive/{commit}.tar.gz".format(
             commit = TOOLCHAINS_ARM_GNU_COMMIT,
         ),
     ],
@@ -46,7 +46,7 @@ use_repo(
 )
 
 register_toolchains(
-    "//toolchain:all",
+    "//toolchain:lm3s6965evb_toolchain",
     "//:qemu_test_runner_toolchain",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -839,7 +839,7 @@
     },
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
-        "bzlTransitiveDigest": "Uhg2vSQY2rksw+nbydQV4xE0U88vI2En97fafK2Z3fM=",
+        "bzlTransitiveDigest": "UMba+++HOK48iEA3d/3VNWIb6QBJPi0lM+Lf0SAJhZk=",
         "usagesDigest": "VvyO6/SX1IsaGXqLW0Snf/LHGTyJCYCGaH4GeEzwXPk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -27,6 +27,26 @@ cc_library(
     alwayslink = True,
 )
 
+_warning_opts = [
+    "-Werror",
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wconversion",
+    "-Wnon-virtual-dtor",
+    "-Wold-style-cast",
+    "-Wcast-align",
+    "-Wunused",
+    "-Woverloaded-virtual",
+    "-Wmisleading-indentation",
+    "-Wnull-dereference",
+    "-Wdouble-promotion",
+    "-Wformat=2",
+    "-Wimplicit-fallthrough",
+    "-Wextra-semi",
+    "-Wunreachable-code",
+]
+
 [
     arm_none_eabi_toolchain(
         name = "{board}_toolchain".format(board = board.name),
@@ -34,42 +54,15 @@ cc_library(
             "//board/{board}:memory_region".format(board = board.name),
             ":start_{cpu}".format(cpu = board.cpu),
         ],
-        copts = [
-            "-mcpu={cpu}".format(cpu = board.cpu),
-            "-mthumb",
-            "-mfloat-abi=soft",
+        copts = common_opts + [
             "-fdiagnostics-color",
-            "-fno-exceptions",
             "-fno-use-cxa-atexit",
-            "-specs=nano.specs",
-            "-Werror",
-            "-Wall",
-            "-Wextra",
-            "-Wpedantic",
-            "-Wconversion",
-            "-Wnon-virtual-dtor",
-            "-Wold-style-cast",
-            "-Wcast-align",
-            "-Wunused",
-            "-Woverloaded-virtual",
-            "-Wmisleading-indentation",
-            "-Wnull-dereference",
-            "-Wdouble-promotion",
-            "-Wformat=2",
-            "-Wimplicit-fallthrough",
-            "-Wextra-semi",
-            "-Wunreachable-code",
         ],
-        cxxopts = [
+        cxxopts = _warning_opts + [
             "-std=c++20",
             "-ffreestanding",
         ],
-        linkopts = [
-            "-mcpu={cpu}".format(cpu = board.cpu),
-            "-mthumb",
-            "-mfloat-abi=soft",
-            "-fno-exceptions",
-            "-specs=nano.specs",
+        linkopts = common_opts + [
             "-Wl,--gc-sections",
             "-Wl,--fatal-warnings",
         ],
@@ -80,5 +73,17 @@ cc_library(
         ],
         visibility = ["//visibility:public"],
     )
-    for board in BOARDS
+    for board, common_opts in [
+        (
+            board,
+            [
+                "-mcpu={cpu}".format(cpu = board.cpu),
+                "-mthumb",
+                "-mfloat-abi=soft",
+                "-fno-exceptions",
+                "-specs=nano.specs",
+            ],
+        )
+        for board in BOARDS
+    ]
 ]


### PR DESCRIPTION
Now that the PR adding additional toolchain config opts (e.g. `cxxopts`)
has been merged, update `@toolchain_arm_gnu` to use a reference from
upstream instead of a fork.

Change-Id: I1d4c0494da0cf5c5407b9f924451b848899b24f7