### PR TITLE
provide a default read-only key for remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,8 @@ common --enable_platform_specific_config
 common:remote-cache --bes_results_url=https://oliverlee.buildbuddy.io/invocation/
 common:remote-cache --bes_backend=grpcs://oliverlee.buildbuddy.io
 common:remote-cache --remote_cache=grpcs://oliverlee.buildbuddy.io
+common:remote-cache --remote_instance_name=cortex_m-instance-0
+common:remote-cache --remote_header=x-buildbuddy-api-key=khiIK9lMQtIp1BztvPQE
 common:remote-cache --remote_timeout=10m
 common:remote-cache --remote_build_event_upload=minimal
 common:remote-cache --remote_download_outputs=minimal

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -30,7 +30,10 @@ runs:
       shell: bash
       run: |
         cp .github/workflows/ci.bazelrc ~/.bazelrc
-        echo 'build:remote-cache --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}' >> ~/.bazelrc
+        rw_api_key="${{ inputs.buildbuddy-api-key }}"
+        if [[ -n "$rw_api_key" ]]; then
+          echo "build:remote-cache --remote_header=x-buildbuddy-api-key=$rw_api_key" >> ~/.bazelrc
+        fi
 
     - name: setup bazel vendored external deps
       shell: bash

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,14 +1,10 @@
-common --build_metadata=ROLE=CI
+common --show_timestamps
+common --announce_rc
+common --color=yes
+common --curses=no
+common --terminal_columns=120
+common --verbose_failures
 
-build --show_timestamps
-build --announce_rc
-build --color=yes
-build --curses=no
-build --terminal_columns=120
-build --verbose_failures
-
-build:remote-cache --remote_upload_local_results=true
-build:remote-cache --remote_instance_name=ci-runner-bazel-stm32-instance-0
-build --config=remote-cache
-
-test --test_output=errors
+common:remote-cache --build_metadata=ROLE=CI
+common:remote-cache --remote_upload_local_results=true
+common --config=remote-cache


### PR DESCRIPTION
Update the `.bazelrc` with a read-only key for the remote cache. Users
may enable use of this key by passing `--config=remote` on the command
line or setting it in `user.bazelrc`.

Change-Id: Ia3c29ce665d4132c94d4d8a1104cfe499790c358