### PR TITLE
add tooling for Nix files

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -7,16 +7,17 @@
   "file_scan_exclusions": [".cache/"],
   "languages": {
     "Nix": {
-      "language_servers": [ "nil", "!nixd" ],
+      "language_servers": ["nixd", "!nil"],
       "formatter": {
-             "external": {
-               "command": "alejandra",
-               "arguments": ["--quiet", "--"]
-             }
-           }
+        "external": {
+          // initialize with
+          // bazel fetch @nixfmt
+          "command": "./external/+flake_package_dev_deps+nixfmt/bin/nixfmt",
+          "arguments": ["--quiet", "--"]
+        }
+      }
     },
     "Starlark": {
-      "enable_language_server": true,
       "language_servers": ["starpls"],
       "formatter": {
         "external": {
@@ -50,6 +51,21 @@
           "--rename-file-limit=0",
           "--log=verbose"
         ]
+      }
+    },
+    "nixd": {
+      "binary": {
+        // initialize with
+        // bazel fetch @nixd
+        "path": "./external/+flake_package_dev_deps+nixd/bin/nixd"
+      },
+      "settings": {
+        "nixpkgs": {
+          "expr": "import (builtins.getFlake \"./tools/nix\").inputs.nixpkgs {}"
+        },
+        "diagnostic": {
+          "suppress": ["sema-unused-def-lambda-noarg-formal"]
+        }
       }
     },
     "starpls": {

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -183,3 +183,15 @@ python = use_extension(
 )
 python.defaults(python_version = "3.11")
 python.toolchain(python_version = "3.11")
+
+flake_package_dev_deps = use_extension(
+    "//extensions:flake_package_deps.bzl",
+    "flake_package_dev_deps",
+    dev_dependency = True,
+)
+use_repo(
+    flake_package_dev_deps,
+    "nixd",
+    "nixfmt",
+    "nixfmt-tree",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -296,7 +296,7 @@
   "moduleExtensions": {
     "//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "lWqARdha1cufgReuIOrWdVn7owprGC5EoSSvIVt7PxE=",
+        "bzlTransitiveDigest": "wNRK3xKVeJCh/YUHDmUKHXEgolV0A6BUL6UQvQDW5Ew=",
         "usagesDigest": "mK4YgaAu5b/qaOsvCSv9KZ6YWfBZ1+idETueZeq0Zgw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -307,6 +307,20 @@
             "attributes": {
               "flake_file": "@@//extensions:flake.nix",
               "flake_lock_file": "@@//extensions:flake.lock"
+            }
+          },
+          "gdb": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "gdb",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"gdb\",\n    out = \"gdb\",\n    src = \"bin/gdb\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
             }
           },
           "qemu-system-arm": {
@@ -322,15 +336,73 @@
               "fail_not_supported": true,
               "legacy_path_syntax": false
             }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "rules_nixpkgs_core",
+            "rules_nixpkgs_core+"
+          ],
+          [
+            "rules_nixpkgs_core+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ]
+        ]
+      }
+    },
+    "//extensions:flake_package_deps.bzl%flake_package_dev_deps": {
+      "general": {
+        "bzlTransitiveDigest": "wNRK3xKVeJCh/YUHDmUKHXEgolV0A6BUL6UQvQDW5Ew=",
+        "usagesDigest": "3VqgbgIsoCYcZdgEvE1x0SA7ofzQrz1Y3WawnvC6qfA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "flake_copy": {
+            "repoRuleId": "@@//extensions:flake_package_deps.bzl%_flake_copy",
+            "attributes": {
+              "flake_file": "@@//extensions:flake.nix",
+              "flake_lock_file": "@@//extensions:flake.lock"
+            }
           },
-          "gdb": {
+          "nixd": {
             "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
             "attributes": {
-              "nix_flake_file": "@@+flake_package_deps+flake_copy//:flake.nix",
-              "nix_flake_lock_file": "@@+flake_package_deps+flake_copy//:flake.lock",
+              "nix_flake_file": "@@+flake_package_dev_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_dev_deps+flake_copy//:flake.lock",
               "nix_flake_file_deps": {},
-              "package": "gdb",
-              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"gdb\",\n    out = \"gdb\",\n    src = \"bin/gdb\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "package": "nixd",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"nixd\",\n    out = \"nixd\",\n    src = \"bin/nixd\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
+            }
+          },
+          "nixfmt": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_dev_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_dev_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "nixfmt",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"nixfmt\",\n    out = \"nixfmt\",\n    src = \"bin/nixfmt\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
+            }
+          },
+          "nixfmt-tree": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_dev_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_dev_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "nixfmt-tree",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"nixfmt-tree\",\n    out = \"treefmt\",\n    src = \"bin/treefmt\",\n    visibility = [\"//visibility:public\"],\n)\n",
               "nixopts": [],
               "quiet": false,
               "fail_not_supported": true,

--- a/extensions/flake.nix
+++ b/extensions/flake.nix
@@ -5,19 +5,33 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    systems = ["x86_64-linux" "aarch64-darwin"];
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-  in {
-    packages = forAllSystems (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        inherit (pkgs) gdb qemu;
-      }
-    );
-  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          inherit (pkgs)
+            gdb
+            qemu
+            nixd
+            nixfmt-tree
+            ;
+          nixfmt = pkgs.nixfmt-rfc-style;
+        }
+      );
+    };
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,8 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+load("@local_workspace_directories//:defs.bzl", "BAZEL_WORKSPACE_ROOT")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
-load("@rules_multirun//:defs.bzl", "multirun")
+load("@rules_multirun//:defs.bzl", "command", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 buildifier(
@@ -14,6 +15,29 @@ buildifier(
     name = "buildifier",
     lint_mode = "warn",
     mode = "fix",
+)
+
+command(
+    name = "nixfmt.check",
+    args = [
+        "--ci",
+        "--tree-root",
+        BAZEL_WORKSPACE_ROOT,
+        "--working-dir",
+        BAZEL_WORKSPACE_ROOT,
+    ],
+    command = "@nixfmt-tree",
+)
+
+command(
+    name = "nixfmt",
+    args = [
+        "--tree-root",
+        BAZEL_WORKSPACE_ROOT,
+        "--working-dir",
+        BAZEL_WORKSPACE_ROOT,
+    ],
+    command = "@nixfmt-tree",
 )
 
 genrule(
@@ -52,6 +76,7 @@ multirun(
     commands = [
         ":buildifier.check",
         ":clang-format.check",
+        ":nixfmt.check",
     ],
 )
 
@@ -60,6 +85,7 @@ multirun(
     commands = [
         ":buildifier",
         ":clang-format",
+        ":nixfmt",
     ],
 )
 

--- a/tools/bazel-wrapper/flake.nix
+++ b/tools/bazel-wrapper/flake.nix
@@ -5,38 +5,48 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    systems = ["x86_64-linux" "aarch64-darwin"];
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-  in {
-    packages = forAllSystems (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-        tools = with pkgs;
-          [
-            bash
-            bazelisk
-            coreutils
-            findutils
-            gnugrep
-            nix
-          ]
-          ++ lib.optionals stdenv.isDarwin [
-            darwin.cctools
-          ];
-      in {
-        default = pkgs.writeShellApplication {
-          name = "bazel-wrapper";
-          runtimeInputs = tools;
-          inheritPath = false;
-          text = ''
-            exec bazelisk "$@"
-          '';
-        };
-      }
-    );
-  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          tools =
+            with pkgs;
+            [
+              bash
+              bazelisk
+              coreutils
+              findutils
+              gnugrep
+              gnused
+              nix
+            ]
+            ++ lib.optionals stdenv.isDarwin [
+              darwin.cctools
+            ];
+        in
+        {
+          default = pkgs.writeShellApplication {
+            name = "bazel-wrapper";
+            runtimeInputs = tools;
+            inheritPath = false;
+            text = ''
+              exec bazelisk "$@"
+            '';
+          };
+        }
+      );
+    };
 }


### PR DESCRIPTION
Define a `flake_package_dev_deps` extension that obtains development
dependencies from nixpkgs. This uses the existing `flake.nix` in
`//extensions`. The dev dependencies include:
* `nixd`
* `nixfmt`
* `nixfmt-tree`

`nixd` (and `nixfmt`) must be fetched explicitly with
```
bazel fetch @nixd
```
as these are only used as part of the Zed project settings.

This PR also adds `gnused` as a package, as it is used extensively by
shell runfiles:
https://github.com/bazelbuild/rules_shell/blob/main/shell/runfiles/runfiles.bash#L184

Change-Id: Ibb8c58fbf876a2eb3c612b3985f45840be7f7d79