### PR TITLE
tag `gdb` targets as `manual`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
 alias(
     name = "gdb",
     actual = "@gdb",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -35,6 +36,7 @@ qemu_runner(
 
 gdb_qemu_runner(
     name = "gdb_qemu_runner",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Avoid eagerly fetching `gdb` if it is not (in)directly requested.

Change-Id: I2385d8f58278af0efd6eddb8f9ae97db836352d9