### PR TITLE
enable aarch64-linux host machines

### DIFF
--- a/extensions/flake.nix
+++ b/extensions/flake.nix
@@ -13,6 +13,7 @@
     let
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);

--- a/tools/bazel-wrapper/flake.nix
+++ b/tools/bazel-wrapper/flake.nix
@@ -13,6 +13,7 @@
     let
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);


### PR DESCRIPTION
Add aarch64-linux as a supported system in the wrapper flake and
extensions flake. This allows a NixOS VM on aarch64-darwin to build this
project.

Co-authored-by: Luke Peterson <hazelnusse@gmail.com>
Change-Id: Ib273b3b6b905aea43692ad25a36c5d78561bf97c