### PR TITLE
use `glibc` sysroot for linux host machines

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -120,11 +120,21 @@ archive_override(
     )],
 )
 
-TOOLCHAINS_LLVM_COMMIT = "7cfc09dffd1305bc05916b6b24352583f3d790a9"
+# this is the current HEAD commit, but we need to patch shebangs
+TOOLCHAINS_LLVM_COMMIT = "0bdeae25025aeb6f914db2a02cb2efeb302743b5"
 
 archive_override(
     module_name = "toolchains_llvm",
-    integrity = "sha256-pxExoYkhpv6w3Lu9PJV4eqRAO9mxv8eI05L3T2lxPvU=",
+    integrity = "sha256-Nqifshn9xrdZEK5cj0ZnuYEPx+SHxKZQClTLDb41tJA=",
+    patch_cmds = [
+        # replace shebangs
+        "sed -i 's|^#!/bin/bash|#!/usr/bin/env bash|' toolchain/cc_wrapper.sh.tpl",
+        "sed -i 's|^#!/bin/bash|#!/usr/bin/env bash|' toolchain/osx_cc_wrapper.sh.tpl",
+        # don't link lm, we'll do that manually
+        # libm.so is a linker script and not a library in nixpkgs
+        # https://github.com/bazel-contrib/toolchains_llvm/blob/0bdeae25025aeb6f914db2a02cb2efeb302743b5/toolchain/cc_toolchain_config.bzl#L201
+        "sed -i 's|\"-lm\",||' toolchain/cc_toolchain_config.bzl",
+    ],
     strip_prefix = "toolchains_llvm-{commit}".format(
         commit = TOOLCHAINS_LLVM_COMMIT,
     ),
@@ -151,6 +161,22 @@ llvm = use_extension(
     "llvm",
     dev_dependency = True,
 )
+llvm.sysroot(
+    name = "llvm_toolchain",
+    label = "@glibc//:sysroot",
+    targets = [
+        "linux-x86_64",
+        "linux-aarch64",
+    ],
+)
+
+llvm_toolchain_sysroot_linkopts = [
+    # Use the actual .so.6 library, not .so files which are linker scripts
+    "-nodefaultlibs",
+    "-l:libm.so.6",
+    "-l:libc.so.6",
+]
+
 llvm.toolchain(
     cxx_flags = {
         "": [
@@ -179,6 +205,11 @@ llvm.toolchain(
             "-Wunreachable-code-return",
         ],
     },
+    # use link_libs to avoid overriding the default linkopts
+    link_libs = {
+        "linux-x86_64": llvm_toolchain_sysroot_linkopts,
+        "linux-aarch64": llvm_toolchain_sysroot_linkopts,
+    },
     llvm_version = "20.1.4",
 )
 use_repo(llvm, "llvm_toolchain")
@@ -203,6 +234,7 @@ flake_package_dev_deps = use_extension(
 )
 use_repo(
     flake_package_dev_deps,
+    "glibc",
     "nixd",
     "nixfmt",
     "nixfmt-tree",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -73,14 +73,14 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.3/MODULE.bazel": "151e30069aaed86e3e23a8060b541a8e9bdebd9b3ee8809c61752cc1aa00ca87",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.3/source.json": "766ee710426042df9dbc07ac794854a427ea288fbde7d3383dcb2ace040ea631",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.2/MODULE.bazel": "a0656c5a8ff7f76bb1319ebf301bab9d94da5b48894cac25a14ed115f9dd0884",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.2/source.json": "8bf0f0bd1678c611565ac7efa1dc64f1afcb20bc44c9969213c742dc5eb87dbc",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -193,13 +193,13 @@
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.13/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.15/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.16/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.17/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.6/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.8/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.0.9/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.1.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.1.3/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_cc/0.2.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_clang_tidy/0.0.0/MODULE.bazel": "d52b77d619bf28dbf2327394c36b8c224e7095b6c5e7e5d5b441116a8f2fff99",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_clang_tidy/0.0.0/source.json": "76aa5c2d020e5b7431be99ad0e7fb0a64f6a9dc74de46713fe5592a85fbed123",
     "https://raw.githubusercontent.com/digiboys/bazel-registry/main/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "not found",
@@ -245,7 +245,7 @@
   "moduleExtensions": {
     "//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "wNRK3xKVeJCh/YUHDmUKHXEgolV0A6BUL6UQvQDW5Ew=",
+        "bzlTransitiveDigest": "kxkFzo6faokOwvSsugWfRrFUl1YoZyDQUh2ULmZWNK0=",
         "usagesDigest": "mK4YgaAu5b/qaOsvCSv9KZ6YWfBZ1+idETueZeq0Zgw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -303,7 +303,7 @@
     },
     "//extensions:flake_package_deps.bzl%flake_package_dev_deps": {
       "general": {
-        "bzlTransitiveDigest": "wNRK3xKVeJCh/YUHDmUKHXEgolV0A6BUL6UQvQDW5Ew=",
+        "bzlTransitiveDigest": "kxkFzo6faokOwvSsugWfRrFUl1YoZyDQUh2ULmZWNK0=",
         "usagesDigest": "3VqgbgIsoCYcZdgEvE1x0SA7ofzQrz1Y3WawnvC6qfA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -314,6 +314,20 @@
             "attributes": {
               "flake_file": "@@//extensions:flake.nix",
               "flake_lock_file": "@@//extensions:flake.lock"
+            }
+          },
+          "glibc": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_dev_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_dev_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "glibc",
+              "build_file_content": "\nfilegroup(\n  name = \"sysroot\",\n  srcs = glob([\"*/**\"]),\n  visibility = [\"//visibility:public\"],\n)\n            ",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
             }
           },
           "nixd": {
@@ -697,7 +711,7 @@
     },
     "@@toolchains_arm_gnu+//:extensions.bzl%arm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "kTqfR1zJvQQ9JYm48vfw+QETXPMHlw+EVElMdATmtuQ=",
+        "bzlTransitiveDigest": "7GyoBh4grGFg/rgV5cJRQoXHKshpZrbgp2ccYQyQWcU=",
         "usagesDigest": "J/cM1VONyJl+MmBHdryf9ZSr03g3eK7d2O2eN1sWQ4I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -806,34 +820,14 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "bazel_features+",
-            "bazel_features_globals",
-            "bazel_features++version_extension+bazel_features_globals"
-          ],
-          [
-            "bazel_features+",
-            "bazel_features_version",
-            "bazel_features++version_extension+bazel_features_version"
-          ],
-          [
-            "protobuf+",
-            "proto_bazel_features",
-            "bazel_features+"
-          ],
-          [
-            "protobuf+",
-            "rules_cc",
-            "rules_cc+"
-          ],
-          [
             "rules_cc+",
             "bazel_tools",
             "bazel_tools"
           ],
           [
             "rules_cc+",
-            "com_google_protobuf",
-            "protobuf+"
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
           ],
           [
             "rules_cc+",
@@ -860,8 +854,8 @@
     },
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
-        "bzlTransitiveDigest": "UMba+++HOK48iEA3d/3VNWIb6QBJPi0lM+Lf0SAJhZk=",
-        "usagesDigest": "VvyO6/SX1IsaGXqLW0Snf/LHGTyJCYCGaH4GeEzwXPk=",
+        "bzlTransitiveDigest": "6J0Uis1p3AmdHq6FLnJuEL6+ZyP37oFSHPZmrf6oHQw=",
+        "usagesDigest": "EeiIEGxVtD/o+nHPBww7Q3dUhQXtCIABmjp7Yp51iV0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -928,8 +922,20 @@
               "exec_os": "",
               "extra_exec_compatible_with": {},
               "extra_target_compatible_with": {},
+              "fastbuild_compile_flags": {},
               "link_flags": {},
-              "link_libs": {},
+              "link_libs": {
+                "linux-x86_64": [
+                  "-nodefaultlibs",
+                  "-l:libm.so.6",
+                  "-l:libc.so.6"
+                ],
+                "linux-aarch64": [
+                  "-nodefaultlibs",
+                  "-l:libm.so.6",
+                  "-l:libc.so.6"
+                ]
+              },
               "llvm_versions": {
                 "": "20.1.4"
               },
@@ -939,11 +945,19 @@
               "target_settings": {},
               "unfiltered_compile_flags": {},
               "toolchain_roots": {},
-              "sysroot": {}
+              "sysroot": {
+                "linux-x86_64": "'@@+flake_package_dev_deps+glibc//:sysroot'",
+                "linux-aarch64": "'@@+flake_package_dev_deps+glibc//:sysroot'"
+              }
             }
           }
         },
         "recordedRepoMappingEntries": [
+          [
+            "",
+            "glibc",
+            "+flake_package_dev_deps+glibc"
+          ],
           [
             "toolchains_llvm+",
             "bazel_skylib",

--- a/extensions/flake.nix
+++ b/extensions/flake.nix
@@ -27,11 +27,31 @@
         {
           inherit (pkgs)
             gdb
-            qemu
             nixd
             nixfmt-tree
+            qemu
             ;
+
           nixfmt = pkgs.nixfmt-rfc-style;
+
+          glibc =
+            let
+              sysroot-base = pkgs.symlinkJoin {
+                name = "sysroot-base";
+                paths = with pkgs; [
+                  glibc
+                  glibc.dev
+                ];
+              };
+            in
+            pkgs.runCommand "sysroot" { } ''
+              cp -r ${sysroot-base} $out
+              chmod -R +w $out
+
+              # these are linker scripts and not libraries
+              rm $out/lib/libc.so
+              rm $out/lib/libm.so
+            '';
         }
       );
     };

--- a/extensions/flake_package_deps.bzl
+++ b/extensions/flake_package_deps.bzl
@@ -87,6 +87,16 @@ flake_package_deps = module_extension(
 
 def _flake_package_dev_deps_impl(_mctx):
     _provide_binary([
+        {
+            "name": "glibc",
+            "build_file_content": """
+filegroup(
+  name = "sysroot",
+  srcs = glob(["*/**"]),
+  visibility = ["//visibility:public"],
+)
+            """,
+        },
         "nixd",
         "nixfmt",
         {

--- a/tools/bazel-wrapper/flake.nix
+++ b/tools/bazel-wrapper/flake.nix
@@ -23,6 +23,10 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          libs = with pkgs; [
+            libxml2
+            libz
+          ];
           tools =
             with pkgs;
             [
@@ -50,6 +54,7 @@
             runtimeInputs = tools;
             inheritPath = false;
             text = ''
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath libs}"
               exec bazelisk "$@"
             '';
           };


### PR DESCRIPTION
On Linux, provide a glibc sysroot from Nixpkgs instead of relying on the
host system to provide one. The LLVM toolchain is also configured to use
this sysroot.

When fetching `@toolchains_llvm`, the shebang is patched for the
`cc_wrapper` script used for Linux, allowing use with NixOS.

The `bazel-wrapper` script now provides `libxml2` and `libz` so that
they can be used by the LLVM toolchain binaries (e.g clang, lld), as
these have shared library dependencies.

Change-Id: Idd176574d437acc34c574ea5d3f5fc820316963a