### PR TITLE
move `diff` out of `bazel-wrapper`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -234,6 +234,7 @@ flake_package_dev_deps = use_extension(
 )
 use_repo(
     flake_package_dev_deps,
+    "diff",
     "glibc",
     "nixd",
     "nixfmt",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -245,7 +245,7 @@
   "moduleExtensions": {
     "//extensions:flake_package_deps.bzl%flake_package_deps": {
       "general": {
-        "bzlTransitiveDigest": "kxkFzo6faokOwvSsugWfRrFUl1YoZyDQUh2ULmZWNK0=",
+        "bzlTransitiveDigest": "rWtqvHprZ0ZFQV/2s5lstiiw/ULASqSrqX6Ep1Db1EQ=",
         "usagesDigest": "mK4YgaAu5b/qaOsvCSv9KZ6YWfBZ1+idETueZeq0Zgw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -303,7 +303,7 @@
     },
     "//extensions:flake_package_deps.bzl%flake_package_dev_deps": {
       "general": {
-        "bzlTransitiveDigest": "kxkFzo6faokOwvSsugWfRrFUl1YoZyDQUh2ULmZWNK0=",
+        "bzlTransitiveDigest": "rWtqvHprZ0ZFQV/2s5lstiiw/ULASqSrqX6Ep1Db1EQ=",
         "usagesDigest": "3VqgbgIsoCYcZdgEvE1x0SA7ofzQrz1Y3WawnvC6qfA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -314,6 +314,20 @@
             "attributes": {
               "flake_file": "@@//extensions:flake.nix",
               "flake_lock_file": "@@//extensions:flake.lock"
+            }
+          },
+          "diff": {
+            "repoRuleId": "@@rules_nixpkgs_core+//:nixpkgs.bzl%_nixpkgs_flake_package",
+            "attributes": {
+              "nix_flake_file": "@@+flake_package_dev_deps+flake_copy//:flake.nix",
+              "nix_flake_lock_file": "@@+flake_package_dev_deps+flake_copy//:flake.lock",
+              "nix_flake_file_deps": {},
+              "package": "diff",
+              "build_file_content": "\nload(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"diff\",\n    out = \"diff\",\n    src = \"bin/diff\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "nixopts": [],
+              "quiet": false,
+              "fail_not_supported": true,
+              "legacy_path_syntax": false
             }
           },
           "glibc": {

--- a/extensions/flake.nix
+++ b/extensions/flake.nix
@@ -34,6 +34,8 @@
 
           nixfmt = pkgs.nixfmt-rfc-style;
 
+          diff = pkgs.diffutils;
+
           glibc =
             let
               sysroot-base = pkgs.symlinkJoin {

--- a/extensions/flake_package_deps.bzl
+++ b/extensions/flake_package_deps.bzl
@@ -87,6 +87,7 @@ flake_package_deps = module_extension(
 
 def _flake_package_dev_deps_impl(_mctx):
     _provide_binary([
+        "diff",
         {
             "name": "glibc",
             "build_file_content": """

--- a/rules/qemu_output_test.bzl
+++ b/rules/qemu_output_test.bzl
@@ -16,7 +16,6 @@ def qemu_output_test(
         local_defines = None,
         copts = None,
         run_under = "//:qemu_runner",
-        diff = "diff -u --color=always --strip-trailing-cr",
         **kwargs):
     cc_binary(
         name = name + ".binary",
@@ -42,6 +41,5 @@ def qemu_output_test(
         expected_stdout = expected_stdout,
         expected_stderr = expected_stderr,
         run_under = run_under,
-        diff = diff,
         **kwargs
     )

--- a/tools/bazel-wrapper/flake.nix
+++ b/tools/bazel-wrapper/flake.nix
@@ -33,7 +33,6 @@
               bash
               bazelisk
               coreutils
-              diffutils
               findutils
               gnugrep
               gnused


### PR DESCRIPTION
Define the `diff` dependency to the extensions flake and out of the
`bazel-wrapper` shell. This avoids an eager fetch of `diff` from nixpkgs
-- instead only fetching it if used by a target.

This also removes use of the `--strip-trailing-cr` option as QEMU no
longer displays monitor output.

Change-Id: I4b16ae2bce1f49c6d1a538a83f6d529e05fb752a